### PR TITLE
feat: enable minimal pwa install support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import { FullscreenToggle } from '@/components/layout/fullscreen-toggle';
 import MainLayout from '@/components/layout/main-layout';
+import { ServiceWorkerRegister } from '@/components/pwa/service-worker-register';
 import { ThemeProvider } from '@/components/theme/theme-provider';
 import { ThemeToggle } from '@/components/theme/theme-toggle';
 import { SidebarTrigger } from '@/components/ui/sidebar';
@@ -16,6 +17,7 @@ export const metadata: Metadata = {
   title: 'Q.V - QuoVadis Sports Training',
   description:
     'Professional sports training platform with offline access to training materials, exercises, and performance tracking',
+  manifest: '/manifest.webmanifest',
   formatDetection: {
     telephone: false,
   },
@@ -33,6 +35,21 @@ export const metadata: Metadata = {
   creator: 'QuoVadis Sports',
   publisher: 'QuoVadis Sports',
   category: 'sports',
+  icons: {
+    icon: [
+      { url: '/assets/icons/favicon-16x16.png', sizes: '16x16', type: 'image/png' },
+      { url: '/assets/icons/favicon-32x32.png', sizes: '32x32', type: 'image/png' },
+      { url: '/assets/icons/favicon-48x48.png', sizes: '48x48', type: 'image/png' },
+    ],
+    shortcut: ['/assets/icons/favicon.ico'],
+    apple: [
+      {
+        url: '/assets/icons/ios/apple-touch-icon.png',
+        sizes: '180x180',
+        type: 'image/png',
+      },
+    ],
+  },
 };
 
 export const viewport: Viewport = {
@@ -60,18 +77,24 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <html lang="de" suppressHydrationWarning>
       <head>
         {/* Favicon */}
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="manifest" href="/manifest.webmanifest" />
+        <link rel="icon" href="/assets/icons/favicon.ico" />
         <link
           rel="icon"
           type="image/png"
           sizes="32x32"
-          href="/icons/icon-32x32.png"
+          href="/assets/icons/favicon-32x32.png"
         />
         <link
           rel="icon"
           type="image/png"
           sizes="16x16"
-          href="/icons/icon-16x16.png"
+          href="/assets/icons/favicon-16x16.png"
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="180x180"
+          href="/assets/icons/ios/apple-touch-icon.png"
         />
       </head>
       <body>
@@ -102,6 +125,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         </ThemeProvider>
         {/* Mobile footer navigation */}
         <MobileFooterNav />
+        <ServiceWorkerRegister />
       </body>
     </html>
   );

--- a/components/pwa/service-worker-register.tsx
+++ b/components/pwa/service-worker-register.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const SERVICE_WORKER_PATH = '/sw.js';
+
+export function ServiceWorkerRegister() {
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (!('serviceWorker' in navigator)) {
+      return;
+    }
+
+    const registerServiceWorker = async () => {
+      try {
+        const registration = await navigator.serviceWorker.register(
+          SERVICE_WORKER_PATH,
+          {
+            scope: '/',
+          },
+        );
+
+        if (process.env.NODE_ENV !== 'production') {
+          console.info('Service worker registered:', registration.scope);
+        }
+      } catch (error) {
+        console.error('Service worker registration failed:', error);
+      }
+    };
+
+    registerServiceWorker();
+  }, []);
+
+  return null;
+}

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,36 @@
+{
+  "name": "QuoVadis Sports Training",
+  "short_name": "Q.V Training",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "description": "Professional sports training platform with installable access to exercises, performance data, and resources.",
+  "lang": "de",
+  "categories": ["sports", "health", "productivity"],
+  "icons": [
+    {
+      "src": "/assets/icons/android/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/assets/icons/android/icon-192-maskable.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/assets/icons/android/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/assets/icons/android/icon-512-maskable.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,7 @@
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});


### PR DESCRIPTION
## Summary
- add a minimal web app manifest that reuses existing icons so the site can be installed
- register a no-op service worker and wire it into the root layout alongside updated icon links

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d63b99afdc8325bf6d39c18c6b2730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Progressive Web App support, enabling “Add to Home Screen” and standalone app experience.
  - Registered a service worker to enable installability and lay groundwork for offline capabilities.
  - Introduced a web app manifest with app metadata, theme colors, and start behavior.
  - Updated app icons (including maskable and Apple touch icons) for better home screen appearance across devices.
- Chores
  - Updated head resources to reference the manifest and new icon paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->